### PR TITLE
initial full sync implementation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ argparse==1.2.1
 msgpack-python==0.4.6
 pyuv==1.2.0
 remote-pdb==1.2.0
-swailing==0.1.1
+swailing==0.1.2
 posix_ipc==1.0.0


### PR DESCRIPTION
@wesc 

Usage:

``` python
c = chain.Client(conf, 0.1)
c.full_sync(obj_id, debug_tags='full-sync-obj-id-0')
```

Output:
`('ok', 'successful full sync for chain 0, updates reenabled on this chain')`

This is a working version of full sync. I tested this by forcing a chain into an inconsistent state (left the old max_seq error in) and checked that the object states are overwritten correctly when full syncing. I also tested adding a node to the chain (as the new head) and removing the tail node leading to the promotion of its predecessor. In all cases full syncing brought the chain to state where it could once again be queried / updated.

I kept with the flow of the CallState and edge case for the sync op at the sanitize, prepare, and commit stages. I made a small change of using `self._op_type` instead of `self._func._op_type` in the CallState. This is because syncing has no associated store func. You mentioned using a dictionary of commands to explicitly define command names and their associated functions (e.g. Store.update) instead of relying on decorators. It was easy enough to edge case without going that route so I didn't bother. But if you think we should do that I'd be happy to implement it.

In any case, here is how full sync works:
1. Sync command arrives at head, node stops accepting updates for that chain.
2. Head forwards command along chain, each node encountered disables updates for the chain.
3. When the sync command reaches the tail, all pending commands are committed. Note that the tail must be a preexisting node in the chain. If it were new it would clear out the object state for that chain. Nodes added to a chain should always be added as non-tail nodes.
4. On the way out, all other nodes drop their pending commits and overwrite the object state with the data from the tail. Each node reenables updates on that chain and returns the object state from the tail to outer nodes.
5. At the head a useful message about the succesful sync is returned to the client instead of the object state.
#### Notes
- This should probably be unit tested ;) I plan to do so when the Handler unit tests are merged in since sync tests would build on them.
- once the full sync code looks good fast sync should be trivial. Some of the sync logic is the same between the two.
- full_sync is a method on chain.Client which is meant to be used by users of WADE. However, in practice this method would be called by the Overlord. Perhaps sync methods should be kept separate e.g. subclass chain.Client and add additional methods and let the overlord use it.
